### PR TITLE
[WIP] [SCHEMAKEEPER] Refactor API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
 - docker pull postgres:9.6
 - docker pull mysql:5.7
 - docker pull quay.io/testcontainers/ryuk:0.2.3
+- docker pull gradle:jdk8-alpine
+- docker pull openjdk:8-jre-alpine
 - sudo apt-get install thrift-compiler
 - sudo apt-get install -y autoconf automake libtool curl make g++ unzip
 - wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-java-3.7.1.tar.gz
@@ -35,6 +37,7 @@ before_script:
   - chmod +x gradlew
 
 install:
+  - docker build -t schemakeeper/server:test .
   - ./gradlew assemble
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 - docker
 
 before_install:
-- docker pull schemakeeper/server:0.1
+- docker build -t schemakeeper/server:test .
 - docker pull postgres:9.6
 - docker pull mysql:5.7
 - docker pull quay.io/testcontainers/ryuk:0.2.3
@@ -37,7 +37,6 @@ before_script:
   - chmod +x gradlew
 
 install:
-  - docker build -t schemakeeper/server:test .
   - ./gradlew assemble
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,16 @@ services:
 - docker
 
 before_install:
-- docker build -t schemakeeper/server:test .
 - docker pull postgres:9.6
 - docker pull mysql:5.7
 - docker pull quay.io/testcontainers/ryuk:0.2.3
 - docker pull gradle:jdk8-alpine
 - docker pull openjdk:8-jre-alpine
+- docker build -t schemakeeper/server:test .
 - sudo apt-get install thrift-compiler
 - sudo apt-get install -y autoconf automake libtool curl make g++ unzip
 - wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-java-3.7.1.tar.gz
-- ls -l
 - tar xfz protobuf-java-3.7.1.tar.gz
-- ls -l
 - cd protobuf-3.7.1 && ./configure && sudo make install && sudo ldconfig
 - cd ./..
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM gradle:jdk8-alpine as builder
-COPY --chown=gradle:gradle . /project
-WORKDIR /project
+COPY --chown=gradle:gradle . /source
+WORKDIR /source
 RUN gradle :schemakeeper-server:clean :schemakeeper-server:jar
 
 FROM openjdk:8-jre-alpine
-COPY --from=builder /project/schemakeeper-server/build/libs/schemakeeper-server-0.1.jar /app/server.jar
+COPY --from=builder /source/schemakeeper-server/build/libs/schemakeeper-server-0.1.jar /app/server.jar
 WORKDIR /app
 CMD java -jar server.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM gradle:jdk8-alpine as builder
-COPY --chown=gradle:gradle . /source
-WORKDIR /source
-RUN gradle :schemakeeper-server:clean :schemakeeper-server:jar
+COPY --chown=gradle:gradle . /project
+WORKDIR /project
+RUN gradle :schemakeeper-server:clean :schemakeeper-server:shadowJar
 
 FROM openjdk:8-jre-alpine
-COPY --from=builder /source/schemakeeper-server/build/libs/schemakeeper-server-0.1.jar /app/server.jar
+COPY --from=builder /project/schemakeeper-server/build/libs/schemakeeper-server-0.1-all.jar /app/server.jar
 WORKDIR /app
 CMD java -jar server.jar

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ compile 'com.nryanov.schemakeeper:${module.name}:${module.version}'
 ```bash
 gradle build
 ```
-Only server:
+Server build:
 ```bash
-gradle :schemakeeper-server:clean :schemakeeper-server:jar
+gradle :schemakeeper-server:clean :schemakeeper-server:shadowJar
 ```
 ### Docker
 ```bash

--- a/README.md
+++ b/README.md
@@ -209,6 +209,32 @@ Get subject metadata by name
     - Code 1000 Backend error
 - Not found 404
     - Code 1001 Subject does not exist
+    
+### updateSubjectSettings
+**PUT /v1/subjects/<subject_name>**
+
+Update subject settings
+
+
+**Body:**
+```json
+{
+ "compatibilityType": "Compatibility type",
+ "isLocked": "true/false"
+}
+```
+
+**Response:**
+- Json object:
+    - subject (string)
+    - compatibilityType (string)
+    - isLocked (boolean)
+
+**Status codes:**
+- Internal server error 500 
+    - Code 1000 Backend error
+- Not found 404
+    - Code 1001 Subject does not exist
 ### subjectVersions
 **GET /v1/subjects/<subject_name>/versions**
 
@@ -259,32 +285,7 @@ Get subject's schema metadata by version
 - Not found 404
     - Code 1001 Subject does not exist
     - Code 1004 Subject schema with such version does not exist
-### lockSubject
-**POST /v1/subjects/<subject_name>/lock**
-
-Lock subject for adding new schemas to it
-
-**Response:**
-- Json boolean
-
-**Status codes:**
-- Internal server error 500 
-    - Code 1000 Backend error
-- Not found 404
-    - Code 1001 Subject does not exist
-### unlockSubject
-**POST /v1/subjects/<subject_name>/unlock**
-
-Unlock subject for adding new schemas to it
-
-**Response:**
-- Json boolean
-
-**Status codes:**
-- Internal server error 500 
-    - Code 1000 Backend error
-- Not found 404
-    - Code 1001 Subject does not exist
+    
 ### schemaById
 **GET /v1/schemas/<id>**
 
@@ -303,7 +304,7 @@ Get schema by id
 - Not found 404
     - Code 1005 Schema does not exist
 ### schemaIdBySubjectAndSchema
-**POST /v1/subjects/<subject_name>/schemas/id**
+**GET /v1/subjects/<subject_name>/schemas/id**
 
 **Body:**
 ```json
@@ -377,42 +378,9 @@ Check schema compatibility
     - Code 1001 Subject does not exist
 - Bad request 400
     - Code 1007 Schema is not valid
-### updateSubjectCompatibility
-**POST /v1/subjects/<subject_name>/compatibility**
-
-**Body:**
-```json
-{
- "compatibilityType": "<compatibility type name>"
-}
-```
-
-Update subject compatibility type
-
-**Response:**
-- Json boolean
-
-**Status codes:**
-- Internal server error 500 
-    - Code 1000 Backend error
-- Bad request 400
-    - Code 1001 Subject does not exist
-### getSubjectCompatibility
-**GET /v1/subjects/<subject_name>/compatibility**
-
-Get subject compatibility type
-
-**Response:**
-- Json object:
-    - compatibilityType (string)
-
-**Status codes:**
-- Internal server error 500 
-    - Code 1000 Backend error
-- Bad request 400
-    - Code 1001 Subject does not exist
+    
 ### registerSchema
-**PUT /v1/schemas**
+**POST /v1/schemas**
 
 **Body:**
 ```json
@@ -436,7 +404,7 @@ Register new schema
     - Code 1008 Schema is already exist
 
 ### registerSchemaAndSubject
-**PUT /v1/subjects/<subject_name>/schemas**
+**POST /v1/subjects/<subject_name>/schemas**
 
 **Body:**
 ```json
@@ -462,7 +430,7 @@ Register new subject (if not exists), schema (if not exists) and connect it to e
     - Code 1010 Schema is not compatible
     - Code 1013 Subject is locked
 ### registerSubject
-**PUT /v1/subjects**
+**POST /v1/subjects**
 
 **Body:**
 ```json
@@ -487,7 +455,7 @@ Register new subject
 - Bad request 400
     - Code 1002 Subject is already exist
 ### addSchemaToSubject
-**PUT /v1/subjects/<subject_name>/schemas/<schema_id>**
+**POST /v1/subjects/<subject_name>/schemas/<schema_id>**
 
 Connect schema to subject as next version
 
@@ -503,17 +471,6 @@ Connect schema to subject as next version
 - Not found 404
     - Code 1001 Subject does not exist
     - Code 1005 Schema does not exist
-### isSubjectExist
-**POST /v1/subjects/<subject_name>**
-
-Check if subject exists
-
-**Response:**
-- Json boolean
-
-**Status codes:**
-- Internal server error 500 
-    - Code 1000 Backend error
 
 ## ROADMAP
 - Add security

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Also, the required property is `SerDeConfig.SCHEMAKEEPER_URL_CONFIG`. Other sett
 
 ## API
 ### subjects
-**GET /v1/subjects**
+**GET /v2/subjects**
 
 Get list of registered subjects
 
@@ -194,7 +194,7 @@ Get list of registered subjects
     - Code 1000 Backend error
 
 ### subjectMetadata
-**GET /v1/subjects/<subject_name>**
+**GET /v2/subjects/<subject_name>**
 
 Get subject metadata by name
 
@@ -211,7 +211,7 @@ Get subject metadata by name
     - Code 1001 Subject does not exist
     
 ### updateSubjectSettings
-**PUT /v1/subjects/<subject_name>**
+**PUT /v2/subjects/<subject_name>**
 
 Update subject settings
 
@@ -236,7 +236,7 @@ Update subject settings
 - Not found 404
     - Code 1001 Subject does not exist
 ### subjectVersions
-**GET /v1/subjects/<subject_name>/versions**
+**GET /v2/subjects/<subject_name>/versions**
 
 Get list of subject's schema versions
 
@@ -249,7 +249,7 @@ Get list of subject's schema versions
 - Not found 404
     - Code 1001 Subject does not exist
 ### subjectSchemasMetadata
-**GET /v1/subjects/<subject_name>/schemas**
+**GET /v2/subjects/<subject_name>/schemas**
 
 Get list of subject's schemas metadata
 
@@ -267,7 +267,7 @@ Get list of subject's schemas metadata
 - Not found 404
     - Code 1001 Subject does not exist
 ### subjectSchemaByVersion
-**GET /v1/subjects/<subject_name>/versions/<version>**
+**GET /v2/subjects/<subject_name>/versions/<version>**
 
 Get subject's schema metadata by version
 
@@ -287,7 +287,7 @@ Get subject's schema metadata by version
     - Code 1004 Subject schema with such version does not exist
     
 ### schemaById
-**GET /v1/schemas/<id>**
+**GET /v2/schemas/<id>**
 
 Get schema by id
 
@@ -304,7 +304,7 @@ Get schema by id
 - Not found 404
     - Code 1005 Schema does not exist
 ### schemaIdBySubjectAndSchema
-**GET /v1/subjects/<subject_name>/schemas/id**
+**POST /v2/subjects/<subject_name>/schemas/id**
 
 **Body:**
 ```json
@@ -329,7 +329,7 @@ Check if schema is registered and connected with current subject and return it's
 - Bad request 400
     - Code 1007 Schema is not valid 
 ### deleteSubject
-**DELETE /v1/subjects/<subject_name>**
+**DELETE /v2/subjects/<subject_name>**
 
 Delete subject metadata
 
@@ -341,7 +341,7 @@ Delete subject metadata
     - Code 1000 Backend error
 
 ### deleteSubjectSchemaByVersion
-**GET /v1/subjects/<subject_name>/versions/<version_number>**
+**DELETE /v2/subjects/<subject_name>/versions/<version_number>**
 
 Delete subject schema by version
 
@@ -356,7 +356,7 @@ Delete subject schema by version
 - Bad request 400
     - Code 1004 Subject schrma with such version does not exist
 ### checkSubjectSchemaCompatibility
-**POST /v1/subjects/<subject_name>/compatibility/schemas**
+**POST /v2/subjects/<subject_name>/compatibility/schemas**
 
 **Body:**
 ```json
@@ -380,7 +380,7 @@ Check schema compatibility
     - Code 1007 Schema is not valid
     
 ### registerSchema
-**POST /v1/schemas**
+**POST /v2/schemas**
 
 **Body:**
 ```json
@@ -404,7 +404,7 @@ Register new schema
     - Code 1008 Schema is already exist
 
 ### registerSchemaAndSubject
-**POST /v1/subjects/<subject_name>/schemas**
+**POST /v2/subjects/<subject_name>/schemas**
 
 **Body:**
 ```json
@@ -430,7 +430,7 @@ Register new subject (if not exists), schema (if not exists) and connect it to e
     - Code 1010 Schema is not compatible
     - Code 1013 Subject is locked
 ### registerSubject
-**POST /v1/subjects**
+**POST /v2/subjects**
 
 **Body:**
 ```json
@@ -455,7 +455,7 @@ Register new subject
 - Bad request 400
     - Code 1002 Subject is already exist
 ### addSchemaToSubject
-**POST /v1/subjects/<subject_name>/schemas/<schema_id>**
+**POST /v2/subjects/<subject_name>/schemas/<schema_id>**
 
 Connect schema to subject as next version
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath "gradle.plugin.org.jruyi.gradle:thrift-gradle-plugin:0.4.1"
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 
@@ -19,6 +20,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'jacoco'
+    apply plugin: 'com.github.johnrengelman.shadow'
 
     repositories {
         mavenCentral()
@@ -206,14 +208,10 @@ project(':schemakeeper-server') {
                 '-language:existentials'
         ]
     }
-
-    jar {
+    
+    shadowJar {
         manifest {
             attributes "Main-Class": "schemakeeper.server.SchemaKeeper"
-        }
-
-        from {
-            configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
         }
     }
 }

--- a/schemakeeper-client/src/main/java/schemakeeper/client/DefaultSchemaKeeperClient.java
+++ b/schemakeeper-client/src/main/java/schemakeeper/client/DefaultSchemaKeeperClient.java
@@ -46,7 +46,7 @@ public class DefaultSchemaKeeperClient extends SchemaKeeperClient {
     public Schema getSchemaById(int id) {
         logger.debug("Get schema by id: {}", id);
 
-        HttpResponse<String> response = Unirest.get(SCHEMAKEEPER_URL + "/v1/schemas/" + id)
+        HttpResponse<String> response = Unirest.get(String.format("%s/%s/schemas/%s", SCHEMAKEEPER_URL, API_VERSION, id))
                 .asString()
                 .ifFailure(res -> {
                     logger.error("Error: {}. Status: {}", res.getBody(), res.getStatus());
@@ -67,7 +67,7 @@ public class DefaultSchemaKeeperClient extends SchemaKeeperClient {
     public int registerNewSchema(String subject, Schema schema, SchemaType schemaType, CompatibilityType compatibilityType) {
         logger.debug("Get schema id ({}) or register new schema and add to subject: {}", schema.toString(), subject);
 
-        HttpResponse<String> response = Unirest.put(SCHEMAKEEPER_URL + "/v1/subjects/" + subject + "/schemas")
+           HttpResponse<String> response = Unirest.post(String.format("%s/%s/subjects/%s/schemas", SCHEMAKEEPER_URL, API_VERSION, subject))
                 .header("Content-Type", "application/json")
                 .body(SubjectAndSchemaRequest.instance(schema, schemaType, compatibilityType))
                 .asString()
@@ -90,7 +90,7 @@ public class DefaultSchemaKeeperClient extends SchemaKeeperClient {
     public int getSchemaId(String subject, Schema schema, SchemaType schemaType) {
         logger.debug("Get schema id ({}) subject: {}", schema.toString(), subject);
 
-        HttpResponse<String> response = Unirest.post(SCHEMAKEEPER_URL + "/v1/subjects/" + subject + "/schemas/id")
+        HttpResponse<String> response = Unirest.request("GET", SCHEMAKEEPER_URL + "/v1/subjects/" + subject + "/schemas/id")
                 .header("Content-Type", "application/json")
                 .body(SchemaText.instance(schema, schemaType))
                 .asString()

--- a/schemakeeper-client/src/main/java/schemakeeper/client/DefaultSchemaKeeperClient.java
+++ b/schemakeeper-client/src/main/java/schemakeeper/client/DefaultSchemaKeeperClient.java
@@ -90,7 +90,7 @@ public class DefaultSchemaKeeperClient extends SchemaKeeperClient {
     public int getSchemaId(String subject, Schema schema, SchemaType schemaType) {
         logger.debug("Get schema id ({}) subject: {}", schema.toString(), subject);
 
-        HttpResponse<String> response = Unirest.request("GET", SCHEMAKEEPER_URL + "/v1/subjects/" + subject + "/schemas/id")
+        HttpResponse<String> response = Unirest.post(String.format("%s/%s/subjects/%s/schemas/id", SCHEMAKEEPER_URL, API_VERSION, subject))
                 .header("Content-Type", "application/json")
                 .body(SchemaText.instance(schema, schemaType))
                 .asString()

--- a/schemakeeper-client/src/main/java/schemakeeper/client/SchemaKeeperClient.java
+++ b/schemakeeper-client/src/main/java/schemakeeper/client/SchemaKeeperClient.java
@@ -10,6 +10,8 @@ import schemakeeper.serialization.SerDeConfig;
 public abstract class SchemaKeeperClient {
     protected final static Logger logger = LoggerFactory.getLogger(SchemaKeeperClient.class);
 
+    protected final static String API_VERSION = "v2";
+
     protected final String SCHEMAKEEPER_URL;
 
     protected SerDeConfig config;

--- a/schemakeeper-client/src/test/java/schemakeeper/client/CachedSchemaKeeperClientTest.java
+++ b/schemakeeper-client/src/test/java/schemakeeper/client/CachedSchemaKeeperClientTest.java
@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CachedSchemaKeeperClientTest {
     private static final Logger logger = LoggerFactory.getLogger(CachedSchemaKeeperClientTest.class);
-    private static final GenericContainer schemakeeperServer = new GenericContainer("schemakeeper/server:0.1")
+    private static final GenericContainer schemakeeperServer = new GenericContainer("schemakeeper/server:test")
             .withExposedPorts(9081)
-            .waitingFor(Wait.forHttp("/v1/subjects"))
+            .waitingFor(Wait.forHttp("/v2/subjects"))
             .withLogConsumer(new Slf4jLogConsumer(logger));
     private static SerDeConfig config;
 

--- a/schemakeeper-client/src/test/java/schemakeeper/client/DefaultSchemaKeeperClientTest.java
+++ b/schemakeeper-client/src/test/java/schemakeeper/client/DefaultSchemaKeeperClientTest.java
@@ -19,9 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class DefaultSchemaKeeperClientTest {
     private static final Logger logger = LoggerFactory.getLogger(DefaultSchemaKeeperClientTest.class);
-    private static final GenericContainer schemakeeperServer = new GenericContainer("schemakeeper/server:0.1")
+    private static final GenericContainer schemakeeperServer = new GenericContainer("schemakeeper/server:test")
             .withExposedPorts(9081)
-            .waitingFor(Wait.forHttp("/v1/subjects"))
+            .waitingFor(Wait.forHttp("/v2/subjects"))
             .withLogConsumer(new Slf4jLogConsumer(logger));
     private static SerDeConfig config;
 

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/SchemaKeeper.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/SchemaKeeper.scala
@@ -32,21 +32,17 @@ object SchemaKeeper extends TwitterServer {
       :+: api.subjectMetadata
       :+: api.subjectVersions
       :+: api.subjectSchemasMetadata
+      :+: api.updateSubjectSettings
       :+: api.subjectSchemaByVersion
-      :+: api.lockSubject
-      :+: api.unlockSubject
       :+: api.schemaIdBySubjectAndSchema
       :+: api.schemaById
       :+: api.deleteSubject
       :+: api.deleteSubjectSchemaByVersion
       :+: api.checkSubjectSchemaCompatibility
-      :+: api.updateSubjectCompatibility
-      :+: api.getSubjectCompatibility
       :+: api.registerSchema
       :+: api.registerSchemaAndSubject
       :+: api.registerSubject
       :+: api.addSchemaToSubject
-      :+: api.isSubjectExist
     )
       .toService
 

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/api/SchemaKeeperApi.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/api/SchemaKeeperApi.scala
@@ -124,7 +124,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val schemaIdBySubjectAndSchema: Endpoint[IO, SchemaId] = get(apiVersion
+  final val schemaIdBySubjectAndSchema: Endpoint[IO, SchemaId] = post(apiVersion
     :: "subjects"
     :: path[String]
     :: "schemas"

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/api/SchemaKeeperApi.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/api/SchemaKeeperApi.scala
@@ -8,6 +8,7 @@ import com.twitter.finagle.http.Status
 import Validation._
 import schemakeeper.api._
 import schemakeeper.schema.CompatibilityType
+import schemakeeper.server.api.internal.SubjectSettings
 import schemakeeper.server.api.protocol.{ErrorCode, ErrorInfo}
 import schemakeeper.server.service._
 import schemakeeper.server.api.protocol.JsonProtocol._
@@ -32,6 +33,22 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     :: path[String]) { subject: String =>
     logger.info(s"Get subject metadata: $subject")
     storage.subjectMetadata(subject).map {
+      case Left(e) =>
+        logger.error(s"Error while getting subject: $subject metadata: ${e.msg}")
+        e match {
+          case s: SubjectDoesNotExist => Output.failure(ErrorInfo(s.msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound)
+          case e: SchemaKeeperError => Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
+        }
+      case Right(v) => Ok(v)
+    }
+  }
+
+  final val updateSubjectSettings: Endpoint[IO, SubjectMetadata] = put(apiVersion
+    :: "subjects"
+    :: path[String]
+    :: jsonBody[SubjectSettings]) { (subject: String, settings: SubjectSettings) =>
+    logger.info(s"Update subject settings: $subject - $settings")
+    storage.updateSubjectSettings(subject, settings.compatibilityType, settings.isLocked).map {
       case Left(e) =>
         logger.error(s"Error while getting subject: $subject metadata: ${e.msg}")
         e match {
@@ -92,38 +109,6 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val lockSubject: Endpoint[IO, Boolean] = post(apiVersion
-    :: "subjects"
-    :: path[String]
-    :: "lock") { subject: String =>
-    logger.info(s"Lock subjecT: $subject")
-    storage.lockSubject(subject).map {
-      case Left(e) =>
-        logger.error(s"Error while locking subject: $subject: ${e.msg}")
-        e match {
-          case s: SubjectDoesNotExist => Output.failure(ErrorInfo(s.msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound)
-          case e: SchemaKeeperError => Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
-        }
-      case Right(v) => Ok(v)
-    }
-  }
-
-  final val unlockSubject: Endpoint[IO, Boolean] = post(apiVersion
-    :: "subjects"
-    :: path[String]
-    :: "unlock") { subject: String =>
-    logger.info(s"Lock subject: $subject")
-    storage.unlockSubject(subject).map {
-      case Left(e) =>
-        logger.error(s"Error while unlocking subject: $subject: ${e.msg}")
-        e match {
-          case s: SubjectDoesNotExist => Output.failure(ErrorInfo(s.msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound)
-          case e: SchemaKeeperError => Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
-        }
-      case Right(v) => Ok(v)
-    }
-  }
-
   final val schemaById: Endpoint[IO, SchemaMetadata] = get(apiVersion
     :: "schemas"
     :: path[Int].should(positiveSchemaId)) { id: Int =>
@@ -139,7 +124,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val schemaIdBySubjectAndSchema: Endpoint[IO, SchemaId] = post(apiVersion
+  final val schemaIdBySubjectAndSchema: Endpoint[IO, SchemaId] = get(apiVersion
     :: "subjects"
     :: path[String]
     :: "schemas"
@@ -208,40 +193,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val updateSubjectCompatibility: Endpoint[IO, Boolean] = post(apiVersion
-    :: "subjects"
-    :: path[String]
-    :: "compatibility"
-    :: jsonBody[CompatibilityType]) { (subject: String, compatibilityType: CompatibilityType) =>
-    logger.info(s"Update subject compatibility: $subject - ${compatibilityType.identifier}")
-    storage.updateSubjectCompatibility(subject, compatibilityType).map {
-      case Left(e) =>
-        logger.error(s"Error while updating subject compatibility: $subject-${compatibilityType.identifier}: ${e.msg}")
-        e match {
-          case s: SubjectDoesNotExist => Output.failure(ErrorInfo(s.msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound)
-          case e: SchemaKeeperError => Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
-        }
-      case Right(v) => Ok(v)
-    }
-  }
-
-  final val getSubjectCompatibility: Endpoint[IO, CompatibilityType] = get(apiVersion
-    :: "subjects"
-    :: path[String]
-    :: "compatibility") { subject: String =>
-    logger.info(s"Get subject compatibility type: $subject")
-    storage.getSubjectCompatibility(subject).map {
-      case Left(e) =>
-        logger.error(s"Error while getting subject compatibility: $subject: ${e.msg}")
-        e match {
-          case s: SubjectDoesNotExist => Output.failure(ErrorInfo(s.msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound)
-          case e: SchemaKeeperError => Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
-        }
-      case Right(v) => Ok(v)
-    }
-  }
-
-  final val registerSchema: Endpoint[IO, SchemaId] = put(apiVersion
+  final val registerSchema: Endpoint[IO, SchemaId] = post(apiVersion
     :: "schemas"
     :: jsonBody[SchemaText]) { schemaText: SchemaText =>
     logger.info(s"Register new schema: $schemaText")
@@ -257,7 +209,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val registerSchemaAndSubject: Endpoint[IO, SchemaId] = put(apiVersion
+  final val registerSchemaAndSubject: Endpoint[IO, SchemaId] = post(apiVersion
     :: "subjects"
     :: path[String]
     :: "schemas"
@@ -277,7 +229,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val registerSubject: Endpoint[IO, SubjectMetadata] = put(apiVersion
+  final val registerSubject: Endpoint[IO, SubjectMetadata] = post(apiVersion
     :: "subjects"
     :: jsonBody[SubjectMetadata]) { meta: SubjectMetadata =>
     logger.info(s"Register new subject: $meta")
@@ -292,7 +244,7 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
     }
   }
 
-  final val addSchemaToSubject: Endpoint[IO, Int] = put(apiVersion
+  final val addSchemaToSubject: Endpoint[IO, Int] = post(apiVersion
     :: "subjects"
     :: path[String]
     :: "schemas"
@@ -311,23 +263,11 @@ class SchemaKeeperApi(storage: Service[IO])(implicit S: ContextShift[IO]) extend
       case Right(v) => Ok(v)
     }
   }
-
-  final val isSubjectExist: Endpoint[IO, Boolean] = post(apiVersion
-    :: "subjects"
-    :: path[String]) { subject: String =>
-    logger.info(s"Check if subject: $subject exists")
-    storage.isSubjectExist(subject).map {
-      case Left(e) =>
-        logger.error(s"Error while checking subject existencee: $subject: ${e.msg}")
-        Output.failure(ErrorInfo(e.msg, ErrorCode.BackendErrorCode), Status.InternalServerError)
-      case Right(v) => Ok(v)
-    }
-  }
 }
 
 object SchemaKeeperApi {
   private val logger = LoggerFactory.getLogger(SchemaKeeperApi.getClass)
-  private val apiVersion = "v1"
+  private val apiVersion = "v2"
 
   def apply(service: Service[IO])(implicit S: ContextShift[IO]): SchemaKeeperApi = new SchemaKeeperApi(service)
 }

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/api/internal/SubjectSettings.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/api/internal/SubjectSettings.scala
@@ -1,0 +1,5 @@
+package schemakeeper.server.api.internal
+
+import schemakeeper.schema.CompatibilityType
+
+case class SubjectSettings(compatibilityType: CompatibilityType, isLocked: Boolean)

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/api/protocol/JsonProtocol.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/api/protocol/JsonProtocol.scala
@@ -39,10 +39,10 @@ object JsonProtocol {
       ("isLocked", Json.fromBoolean(a.isLocked)),
     )
   }
-  implicit val subjectSettingsDencoder: Decoder[SubjectSettings] = new Decoder[SubjectSettings] {
+  implicit val subjectSettingsDecoder: Decoder[SubjectSettings] = new Decoder[SubjectSettings] {
     override def apply(c: HCursor): Result[SubjectSettings] = for {
-      compatibilityType <- c.downField("schemaId").as[String]
-      isLocked <- c.downField("schemaText").as[Boolean]
+      compatibilityType <- c.downField("compatibilityType").as[String]
+      isLocked <- c.downField("isLocked").as[Boolean]
     } yield SubjectSettings(CompatibilityType.findByName(compatibilityType), isLocked)
   }
 

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/api/protocol/JsonProtocol.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/api/protocol/JsonProtocol.scala
@@ -4,6 +4,7 @@ import io.circe.Decoder.Result
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import schemakeeper.api._
 import schemakeeper.schema.{CompatibilityType, SchemaType}
+import schemakeeper.server.api.internal.SubjectSettings
 
 object JsonProtocol {
     implicit val exceptionEncoder: Encoder[Exception] = Encoder.instance {
@@ -30,6 +31,19 @@ object JsonProtocol {
       schemaHash <- c.downField("schemaHash").as[String]
       schemaType <- c.downField("schemaType").as[String]
     } yield SchemaMetadata.instance(schemaId, schemaText, schemaHash, SchemaType.findByName(schemaType))
+  }
+
+  implicit val subjectSettingsEncoder: Encoder[SubjectSettings] = new Encoder[SubjectSettings] {
+    override def apply(a: SubjectSettings): Json = Json.obj(
+      ("compatibilityType", Json.fromString(a.compatibilityType.identifier)),
+      ("isLocked", Json.fromBoolean(a.isLocked)),
+    )
+  }
+  implicit val subjectSettingsDencoder: Decoder[SubjectSettings] = new Decoder[SubjectSettings] {
+    override def apply(c: HCursor): Result[SubjectSettings] = for {
+      compatibilityType <- c.downField("schemaId").as[String]
+      isLocked <- c.downField("schemaText").as[Boolean]
+    } yield SubjectSettings(CompatibilityType.findByName(compatibilityType), isLocked)
   }
 
   implicit val subjectSchemaMetadataEncoder: Encoder[SubjectSchemaMetadata] = new Encoder[SubjectSchemaMetadata] {

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/service/Service.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/service/Service.scala
@@ -16,22 +16,19 @@ trait Service[F[_]] {
   def subjectMetadata(subject: String): F[Either[SchemaKeeperError, SubjectMetadata]]
 
   /**
+    * Update settings for subject
+    * @param subject - subject name
+    * @param compatibilityType - new compatibilityType
+    * @param isLocked - lock/unlock subject
+    * @return - updated subject settings
+    */
+  def updateSubjectSettings(subject: String, compatibilityType: CompatibilityType, isLocked: Boolean): F[Either[SchemaKeeperError, SubjectMetadata]]
+
+  /**
     * @param subject - subject name
     * @return - registered schema versions
     */
   def subjectVersions(subject: String): F[Either[SchemaKeeperError, List[Int]]]
-
-  /**
-    * @param subject - subject name
-    * @return - operation result
-    */
-  def lockSubject(subject: String): F[Either[SchemaKeeperError, Boolean]]
-
-  /**
-    * @param subject - subject name
-    * @return - operation result
-    */
-  def unlockSubject(subject: String): F[Either[SchemaKeeperError, Boolean]]
 
   /**
     * @param subject - subject name
@@ -83,25 +80,6 @@ trait Service[F[_]] {
 
   /**
     * @param subject - subject name
-    * @param compatibilityType - new compatibility type
-    * @return - compatiiblity type if type was updated successfully otherwise none
-    */
-  def updateSubjectCompatibility(subject: String, compatibilityType: CompatibilityType): F[Either[SchemaKeeperError, Boolean]]
-
-  /**
-    * @param subject - subject name
-    * @return - compatibility type or none if subject with specified name does not exist
-    */
-  def getSubjectCompatibility(subject: String): F[Either[SchemaKeeperError, CompatibilityType]]
-
-  /**
-    * @param subject - subject name
-    * @return - last subject schema or none
-    */
-  def getLastSubjectSchema(subject: String): F[Either[SchemaKeeperError, SchemaMetadata]]
-
-  /**
-    * @param subject - subject name
     * @return - list of subject schemas or empty list
     */
   def getSubjectSchemas(subject: String): F[Either[SchemaKeeperError, List[SchemaMetadata]]]
@@ -142,10 +120,4 @@ trait Service[F[_]] {
     * @return - next version number
     */
   def addSchemaToSubject(subject: String, schemaId: Int): F[Either[SchemaKeeperError, Int]]
-
-  /**
-    * @param subject - subject name
-    * @return - true if subject exists otherwise false
-    */
-  def isSubjectExist(subject: String): F[Either[SchemaKeeperError, Boolean]]
 }

--- a/schemakeeper-server/src/main/scala/schemakeeper/server/storage/SchemaStorage.scala
+++ b/schemakeeper-server/src/main/scala/schemakeeper/server/storage/SchemaStorage.scala
@@ -24,15 +24,11 @@ trait SchemaStorage[F[_]] {
 
   /**
     * @param subject - subject name
-    * @return - operation result
+    * @param compatibilityType - compatibility type
+    * @param isLocked - subject lock status
+    * @return - subject metadata
     */
-  def lockSubject(subject: String): F[Boolean]
-
-  /**
-    * @param subject - subject name
-    * @return - operation result
-    */
-  def unlockSubject(subject: String): F[Boolean]
+  def updateSubjectSettings(subject: String, compatibilityType: CompatibilityType, isLocked: Boolean): F[SubjectMetadata]
 
   /**
     * @param subject - subject name
@@ -71,13 +67,6 @@ trait SchemaStorage[F[_]] {
     * @return - true if subject schema was deleted otherwise false
     */
   def deleteSubjectSchemaByVersion(subject: String, version: Int): F[Boolean]
-
-  /**
-    * @param subject - subject name
-    * @param compatibilityType - new compatibility type
-    * @return - true if compatibility type was updated otherwise false
-    */
-  def updateSubjectCompatibility(subject: String, compatibilityType: CompatibilityType): F[Boolean]
 
   /**
     * @param subject - subject name

--- a/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
+++ b/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
@@ -98,15 +98,15 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectSettings(CompatibilityType.FORWARD, isLocked = true)
-      val result = api.subjectMetadata(Input.put("/v2/subjects/A1").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.updateSubjectSettings(Input.put("/v2/subjects/A1").withBody[Application.Json](body)).awaitValueUnsafe()
 
-      assertResult(body)(result.get)
+      assertResult(SubjectMetadata.instance("A1", CompatibilityType.FORWARD, true))(result.get)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectSettings(CompatibilityType.FORWARD, isLocked = true)
-      val result = api.subjectMetadata(Input.put("/v2/subjects/A1")).awaitOutputUnsafe()
+      val result = api.updateSubjectSettings(Input.put("/v2/subjects/A1").withBody[Application.Json](body)).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }

--- a/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
+++ b/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
@@ -15,6 +15,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpec}
 import org.scalatestplus.junit.JUnitRunner
 import schemakeeper.api._
 import schemakeeper.schema.{CompatibilityType, SchemaType}
+import schemakeeper.server.api.internal.SubjectSettings
 import schemakeeper.server.{Configuration, service}
 import schemakeeper.server.api.protocol.{ErrorCode, ErrorInfo}
 import schemakeeper.server.api.protocol.JsonProtocol._
@@ -62,14 +63,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return subject list" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjects(Input.get("/v1/subjects")).awaitValueUnsafe()
+      val result = api.subjects(Input.get("/v2/subjects")).awaitValueUnsafe()
 
       assertResult(List("A1"))(result.get)
     }
 
     "return empty subject list" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjects(Input.get("/v1/subjects")).awaitValueUnsafe()
+      val result = api.subjects(Input.get("/v2/subjects")).awaitValueUnsafe()
 
       assert(result.get.isEmpty)
     }
@@ -79,48 +80,33 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return subject metadata" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectMetadata(Input.get("/v1/subjects/A1")).awaitValueUnsafe()
+      val result = api.subjectMetadata(Input.get("/v2/subjects/A1")).awaitValueUnsafe()
 
       assertResult(SubjectMetadata.instance("A1", CompatibilityType.BACKWARD))(result.get)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectMetadata(Input.get("/v1/subjects/A1")).awaitOutputUnsafe()
+      val result = api.subjectMetadata(Input.get("/v2/subjects/A1")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
   }
 
-  "LockSubject endpoint" should {
-    "return true" in {
+  "UpdateSubjectSettings endpoint" should {
+    "return updated subject metadata" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.lockSubject(Input.post("/v1/subjects/A1/lock")).awaitValueUnsafe()
+      val body = SubjectSettings(CompatibilityType.FORWARD, isLocked = true)
+      val result = api.subjectMetadata(Input.put("/v2/subjects/A1").withBody[Application.Json](body)).awaitValueUnsafe()
 
-      assert(result.get)
+      assertResult(body)(result.get)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.lockSubject(Input.post("/v1/subjects/A1/lock")).awaitOutputUnsafe()
-
-      assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
-    }
-  }
-
-  "UnlockSubject endpoint" should {
-    "return true" in {
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.unlockSubject(Input.post("/v1/subjects/A1/unlock")).awaitValueUnsafe()
-
-      assert(result.get)
-    }
-
-    "NotFound - subject does not exist" in {
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.unlockSubject(Input.post("/v1/subjects/A1/unlock")).awaitOutputUnsafe()
+      val body = SubjectSettings(CompatibilityType.FORWARD, isLocked = true)
+      val result = api.subjectMetadata(Input.put("/v2/subjects/A1")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
@@ -130,7 +116,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return versions list" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectVersions(Input.get("/v1/subjects/A1/versions")).awaitValueUnsafe()
+      val result = api.subjectVersions(Input.get("/v2/subjects/A1/versions")).awaitValueUnsafe()
 
       assertResult(List(1))(result.get)
     }
@@ -138,14 +124,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return empty versions list" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectVersions(Input.get("/v1/subjects/A1/versions")).awaitValueUnsafe()
+      val result = api.subjectVersions(Input.get("/v2/subjects/A1/versions")).awaitValueUnsafe()
 
       assert(result.get.isEmpty)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectVersions(Input.get("/v1/subjects/A1/versions")).awaitOutputUnsafe()
+      val result = api.subjectVersions(Input.get("/v2/subjects/A1/versions")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
@@ -155,7 +141,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return meta list" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemasMetadata(Input.get("/v1/subjects/A1/schemas")).awaitValueUnsafe()
+      val result = api.subjectSchemasMetadata(Input.get("/v2/subjects/A1/schemas")).awaitValueUnsafe()
 
       assertResult(1)(result.get.length)
     }
@@ -163,14 +149,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return empty list" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemasMetadata(Input.get("/v1/subjects/A1/schemas")).awaitValueUnsafe()
+      val result = api.subjectSchemasMetadata(Input.get("/v2/subjects/A1/schemas")).awaitValueUnsafe()
 
       assert(result.get.isEmpty)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemasMetadata(Input.get("/v1/subjects/A1/schemas")).awaitOutputUnsafe()
+      val result = api.subjectSchemasMetadata(Input.get("/v2/subjects/A1/schemas")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
@@ -180,14 +166,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return meta" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemaByVersion(Input.get("/v1/subjects/A1/versions/1")).awaitValueUnsafe()
+      val result = api.subjectSchemaByVersion(Input.get("/v2/subjects/A1/versions/1")).awaitValueUnsafe()
 
       assertResult(Schema.create(Schema.Type.STRING).toString)(result.get.getSchemaText)
     }
 
     "NotFound - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemaByVersion(Input.get("/v1/subjects/A1/versions/1")).awaitOutputUnsafe()
+      val result = api.subjectSchemaByVersion(Input.get("/v2/subjects/A1/versions/1")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
@@ -195,14 +181,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "NotFound - subject has no schema with such version" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.subjectSchemaByVersion(Input.get("/v1/subjects/A1/versions/2")).awaitOutputUnsafe()
+      val result = api.subjectSchemaByVersion(Input.get("/v2/subjects/A1/versions/2")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectSchemaVersionDoesNotExist("A1", 2).msg, ErrorCode.SubjectSchemaVersionDoesNotExistCode), Status.NotFound))(result.get)
     }
 
     "throws validation error" in {
       val api = SchemaKeeperApi(schemaStorage)
-      assertThrows[NotValid](api.subjectSchemaByVersion(Input.get("/v1/subjects/A1/versions/-1")).awaitOutputUnsafe())
+      assertThrows[NotValid](api.subjectSchemaByVersion(Input.get("/v2/subjects/A1/versions/-1")).awaitOutputUnsafe())
     }
   }
 
@@ -210,20 +196,20 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return meta" in {
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaById(Input.get(s"/v1/schemas/$id")).awaitValueUnsafe()
+      val result = api.schemaById(Input.get(s"/v2/schemas/$id")).awaitValueUnsafe()
 
       assertResult(id)(result.get.getSchemaId)
     }
 
     "NotFound - schema with specified id does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaById(Input.get(s"/v1/schemas/1")).awaitOutputUnsafe()
+      val result = api.schemaById(Input.get(s"/v2/schemas/1")).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIdDoesNotExist(1).msg, ErrorCode.SchemaIdDoesNotExistCode), Status.NotFound))(result.get)
     }
 
     "throws validation error" in {
       val api = SchemaKeeperApi(schemaStorage)
-      assertThrows[NotValid](api.schemaById(Input.get(s"/v1/schemas/-1")).awaitOutputUnsafe())
+      assertThrows[NotValid](api.schemaById(Input.get(s"/v2/schemas/-1")).awaitOutputUnsafe())
     }
   }
 
@@ -232,7 +218,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync().right.get
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v1/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
 
       assertResult(id)(result.get)
     }
@@ -241,14 +227,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v1/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotRegistered(Schema.create(Schema.Type.STRING).toString()).msg, ErrorCode.SchemaIsNotRegisteredCode), Status.NotFound))(result.get)
     }
 
     "BadRequest - schema is not valid" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance("not valid schema")
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v1/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
 
@@ -257,7 +243,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString(), SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v1/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsNotConnectedToSchema("A1", id).msg, ErrorCode.SubjectIsNotConnectedToSchemaCode), Status.BadRequest))(result.get)
     }
   }
@@ -266,14 +252,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return true" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.deleteSubject(Input.delete(s"/v1/subjects/A1")).awaitValueUnsafe()
+      val result = api.deleteSubject(Input.delete(s"/v2/subjects/A1")).awaitValueUnsafe()
 
       assert(result.get)
     }
 
     "return false" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.deleteSubject(Input.delete(s"/v1/subjects/A1")).awaitValueUnsafe()
+      val result = api.deleteSubject(Input.delete(s"/v2/subjects/A1")).awaitValueUnsafe()
 
       assert(!result.get)
     }
@@ -283,14 +269,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return true" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v1/subjects/A1/versions/1")).awaitValueUnsafe()
+      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v2/subjects/A1/versions/1")).awaitValueUnsafe()
 
       assert(result.get)
     }
 
     "BadRequest - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v1/subjects/A1/versions/1")).awaitOutputUnsafe()
+      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v2/subjects/A1/versions/1")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
@@ -298,14 +284,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "BadRequest - specified version does not exist" in {
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v1/subjects/A1/versions/123")).awaitOutputUnsafe()
+      val result = api.deleteSubjectSchemaByVersion(Input.delete("/v2/subjects/A1/versions/123")).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(service.SubjectSchemaVersionDoesNotExist("A1", 123).msg, ErrorCode.SubjectSchemaVersionDoesNotExistCode), Status.NotFound))(result.get)
     }
 
     "throws validation error" in {
       val api = SchemaKeeperApi(schemaStorage)
-      assertThrows[NotValid](api.deleteSubjectSchemaByVersion(Input.delete("/v1/subjects/A1/versions/-1")).awaitOutputUnsafe())
+      assertThrows[NotValid](api.deleteSubjectSchemaByVersion(Input.delete("/v2/subjects/A1/versions/-1")).awaitOutputUnsafe())
     }
   }
 
@@ -314,7 +300,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.NONE, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance(Schema.create(Schema.Type.INT).toString)
-      val result = api.checkSubjectSchemaCompatibility(Input.post("/v1/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.checkSubjectSchemaCompatibility(Input.post("/v2/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
       assert(result.get)
     }
 
@@ -322,7 +308,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance(Schema.create(Schema.Type.INT).toString)
-      val result = api.checkSubjectSchemaCompatibility(Input.post("/v1/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.checkSubjectSchemaCompatibility(Input.post("/v2/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
       assert(!result.get)
     }
 
@@ -330,7 +316,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance("not valid schema")
-      val result = api.checkSubjectSchemaCompatibility(Input.post("/v1/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.checkSubjectSchemaCompatibility(Input.post("/v2/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
 
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
@@ -338,39 +324,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "BadRequest - subject does not exist" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance(Schema.create(Schema.Type.INT).toString)
-      val result = api.checkSubjectSchemaCompatibility(Input.post("/v1/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
-      assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
-    }
-  }
-
-  "UpdateSubjectCompatibility endpoint" should {
-    "return true" in {
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
-      val api = SchemaKeeperApi(schemaStorage)
-      val body = CompatibilityType.FORWARD
-      val result = api.updateSubjectCompatibility(Input.post("/v1/subjects/A1/compatibility").withBody[Application.Json](body)).awaitValueUnsafe()
-      assert(result.get)
-    }
-
-    "BadRequest - subject does not exist" in {
-      val api = SchemaKeeperApi(schemaStorage)
-      val body = CompatibilityType.FORWARD
-      val result = api.updateSubjectCompatibility(Input.post("/v1/subjects/A1/compatibility").withBody[Application.Json](body)).awaitOutputUnsafe()
-      assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
-    }
-  }
-
-  "GetSubjectCompatibility endpoint" should {
-    "return compatibilityType" in {
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.getSubjectCompatibility(Input.get("/v1/subjects/A1/compatibility")).awaitValueUnsafe()
-      assertResult(CompatibilityType.BACKWARD)(result.get)
-    }
-
-    "NoContent - subject does not exist" in {
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.getSubjectCompatibility(Input.get("/v1/subjects/A1/compatibility")).awaitOutputUnsafe()
+      val result = api.checkSubjectSchemaCompatibility(Input.post("/v2/subjects/A1/compatibility/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
   }
@@ -379,14 +333,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return schemaId" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING).toString)
-      val result = api.registerSchema(Input.put("/v1/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.registerSchema(Input.post("/v2/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
       assert(result.get.isInstanceOf[SchemaId])
     }
 
     "BadRequest - schema is not valid" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance("not valid schema")
-      val result = api.registerSchema(Input.put("/v1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSchema(Input.post("/v2/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
 
@@ -395,7 +349,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val schema = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO).unsafeRunSync()
       val id = schema.right.get.getSchemaId
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
-      val result = api.registerSchema(Input.put("/v1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSchema(Input.post("/v2/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsAlreadyExist(id, Schema.create(Schema.Type.STRING).toString()).msg, ErrorCode.SchemaIsAlreadyExistCode), Status.BadRequest))(result.get)
     }
   }
@@ -404,7 +358,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return schemaId" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectAndSchemaRequest.instance(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO, CompatibilityType.BACKWARD)
-      val result = api.registerSchemaAndSubject(Input.put("/v1/subjects/A1/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.registerSchemaAndSubject(Input.post("/v2/subjects/A1/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
       assert(result.get.isInstanceOf[SchemaId])
     }
 
@@ -412,23 +366,22 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync().right.get
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectAndSchemaRequest.instance(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO, CompatibilityType.BACKWARD)
-      val result = api.registerSchemaAndSubject(Input.put("/v1/subjects/A1/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.registerSchemaAndSubject(Input.post("/v2/subjects/A1/schemas").withBody[Application.Json](body)).awaitValueUnsafe()
       assertResult(id)(result.get)
     }
 
     "BadRequest - schema is not valid" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectAndSchemaRequest.instance("not valid schema", SchemaType.AVRO, CompatibilityType.BACKWARD)
-      val result = api.registerSchemaAndSubject(Input.put("/v1/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSchemaAndSubject(Input.post("/v2/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
 
     "BadRequest - subject is locked" in {
       val api = SchemaKeeperApi(schemaStorage)
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
-      schemaStorage.lockSubject("A1").unsafeRunSync()
+      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = true).unsafeRunSync()
       val body = SubjectAndSchemaRequest.instance(Schema.create(Schema.Type.INT).toString, SchemaType.AVRO, CompatibilityType.BACKWARD)
-      val result = api.registerSchemaAndSubject(Input.put("/v1/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSchemaAndSubject(Input.post("/v2/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsLocked("A1").msg, ErrorCode.SubjectIsLockedErrorCode), Status.BadRequest))(result.get)
     }
 
@@ -436,7 +389,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.INT).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectAndSchemaRequest.instance(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO, CompatibilityType.BACKWARD)
-      val result = api.registerSchemaAndSubject(Input.put("/v1/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSchemaAndSubject(Input.post("/v2/subjects/A1/schemas").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(service.SchemaIsNotCompatible("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD).msg, ErrorCode.SchemaIsNotCompatibleCode), Status.BadRequest))(result.get)
     }
   }
@@ -445,14 +398,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
     "return ok" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectMetadata.instance("A1", CompatibilityType.BACKWARD)
-      val result = api.registerSubject(Input.put("/v1/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSubject(Input.post("/v2/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Ok(SubjectMetadata.instance("A1", CompatibilityType.BACKWARD)))(result.get)
     }
 
     "return ok - register locked subject" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectMetadata.instance("A1", CompatibilityType.BACKWARD, true)
-      val result = api.registerSubject(Input.put("/v1/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSubject(Input.post("/v2/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Ok(SubjectMetadata.instance("A1", CompatibilityType.BACKWARD, true)))(result.get)
     }
 
@@ -460,7 +413,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
       val body = SubjectMetadata.instance("A1", CompatibilityType.BACKWARD)
-      val result = api.registerSubject(Input.put("/v1/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.registerSubject(Input.post("/v2/subjects").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsAlreadyExists("A1").msg, ErrorCode.SubjectIsAlreadyExistsCode), Status.BadRequest))(result.get)
     }
   }
@@ -470,7 +423,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/$id")).awaitValueUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/$id")).awaitValueUnsafe()
       assert(result.contains(1))
     }
 
@@ -478,58 +431,42 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.NONE, SchemaType.AVRO).unsafeRunSync()
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.INT).toString, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/$id")).awaitValueUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/$id")).awaitValueUnsafe()
       assert(result.contains(2))
     }
 
     "BadRequest - subject and schema are already connected" in {
       val id = schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.NONE, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/$id")).awaitOutputUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/$id")).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsAlreadyConnectedToSchema("A1", id).msg, ErrorCode.SubjectIsAlreadyConnectedToSchemaCode), Status.BadRequest))(result.get)
     }
 
     "BadRequest - subject is locked" in {
       val api = SchemaKeeperApi(schemaStorage)
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
+      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = true).unsafeRunSync()
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
-      schemaStorage.lockSubject("A1").unsafeRunSync()
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/$id")).awaitOutputUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/$id")).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsLocked("A1").msg, ErrorCode.SubjectIsLockedErrorCode), Status.BadRequest))(result.get)
     }
 
     "NotFound - subject does not exist" in {
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.INT).toString, SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/$id")).awaitOutputUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/$id")).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectDoesNotExist("A1").msg, ErrorCode.SubjectDoesNotExistCode), Status.NotFound))(result.get)
     }
 
     "NotFound - schema does not exist" in {
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.addSchemaToSubject(Input.put(s"/v1/subjects/A1/schemas/123")).awaitOutputUnsafe()
+      val result = api.addSchemaToSubject(Input.post(s"/v2/subjects/A1/schemas/123")).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIdDoesNotExist(123).msg, ErrorCode.SchemaIdDoesNotExistCode), Status.NotFound))(result.get)
     }
 
     "throws validation error" in {
       val api = SchemaKeeperApi(schemaStorage)
-      assertThrows[NotValid](api.addSchemaToSubject(Input.put("/v1/subjects/A1/schemas/-1")).awaitOutputUnsafe())
-    }
-  }
-
-  "IsSubjectExist endpoint" should {
-    "return true" in {
-      schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false)
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.isSubjectExist(Input.post("/v1/subjects/A1")).awaitValueUnsafe()
-      assert(result.get)
-    }
-
-    "return false" in {
-      val api = SchemaKeeperApi(schemaStorage)
-      val result = api.isSubjectExist(Input.post("/v1/subjects/A1")).awaitValueUnsafe()
-      assert(!result.get)
+      assertThrows[NotValid](api.addSchemaToSubject(Input.post("/v2/subjects/A1/schemas/-1")).awaitOutputUnsafe())
     }
   }
 }

--- a/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
+++ b/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
@@ -218,7 +218,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync().right.get
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
 
       assertResult(id)(result.get)
     }
@@ -227,14 +227,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotRegistered(Schema.create(Schema.Type.STRING).toString()).msg, ErrorCode.SchemaIsNotRegisteredCode), Status.NotFound))(result.get)
     }
 
     "BadRequest - schema is not valid" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance("not valid schema")
-      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
 
@@ -243,7 +243,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString(), SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsNotConnectedToSchema("A1", id).msg, ErrorCode.SubjectIsNotConnectedToSchemaCode), Status.BadRequest))(result.get)
     }
   }

--- a/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
+++ b/schemakeeper-server/src/test/scala/schemakeeper/server/api/SchemaKeeperApiTest.scala
@@ -218,7 +218,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema("A1", Schema.create(Schema.Type.STRING).toString, CompatibilityType.BACKWARD, SchemaType.AVRO).unsafeRunSync().right.get
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitValueUnsafe()
 
       assertResult(id)(result.get)
     }
@@ -227,14 +227,14 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       schemaStorage.registerSubject("A1", CompatibilityType.BACKWARD, isLocked = false).unsafeRunSync()
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotRegistered(Schema.create(Schema.Type.STRING).toString()).msg, ErrorCode.SchemaIsNotRegisteredCode), Status.NotFound))(result.get)
     }
 
     "BadRequest - schema is not valid" in {
       val api = SchemaKeeperApi(schemaStorage)
       val body = SchemaText.instance("not valid schema")
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SchemaIsNotValid("not valid schema").msg, ErrorCode.SchemaIsNotValidCode), Status.BadRequest))(result.get)
     }
 
@@ -243,7 +243,7 @@ class SchemaKeeperApiTest extends WordSpec with Matchers with BeforeAndAfterEach
       val id = schemaStorage.registerSchema(Schema.create(Schema.Type.STRING).toString(), SchemaType.AVRO).unsafeRunSync().right.get.getSchemaId
       val body = SchemaText.instance(Schema.create(Schema.Type.STRING))
       val api = SchemaKeeperApi(schemaStorage)
-      val result = api.schemaIdBySubjectAndSchema(Input.post(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
+      val result = api.schemaIdBySubjectAndSchema(Input.get(s"/v2/subjects/A1/schemas/id").withBody[Application.Json](body)).awaitOutputUnsafe()
       assertResult(Output.failure(ErrorInfo(SubjectIsNotConnectedToSchema("A1", id).msg, ErrorCode.SubjectIsNotConnectedToSchemaCode), Status.BadRequest))(result.get)
     }
   }

--- a/schemakeeper-server/src/test/scala/schemakeeper/server/api/protocol/JsonProtocolTest.scala
+++ b/schemakeeper-server/src/test/scala/schemakeeper/server/api/protocol/JsonProtocolTest.scala
@@ -7,9 +7,19 @@ import JsonProtocol._
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 import schemakeeper.schema.{CompatibilityType, SchemaType}
+import schemakeeper.server.api.internal.SubjectSettings
 
 @RunWith(classOf[JUnitRunner])
 class JsonProtocolTest extends WordSpec with Matchers {
+  "SubjectSettings" should {
+    "be encoded and decoded correctly" in {
+      val meta = SubjectSettings(CompatibilityType.BACKWARD, isLocked = true)
+      val json = meta.asJson
+
+      assert(json.as[SubjectSettings].contains(meta))
+    }
+  }
+
   "SchemaMetadata" should {
     "be encoded and decoded correctly" in {
       val meta = SchemaMetadata.instance(1, "b", "c")


### PR DESCRIPTION
- Use POST method instead of PUT for creating subject, schema, subject and schema
- Use POST method instead of PUT for connecting subject and schema
- Remove lock/unlock getCompatibilityType/updateCompatibilityType
- Add endpoint for updating subject's settings
- Other minor updates
- Update client
- Bump API version to v2